### PR TITLE
Addition of routing.iptablesMode

### DIFF
--- a/signadot/operator/README.md
+++ b/signadot/operator/README.md
@@ -320,9 +320,11 @@ Note that, unlike with Istio, routing in Linkerd is not expressed via Linkerd CR
 
 ### Routing parameters
 
-| Name                    | Description                                     | Default |
-| ----------------------- | ----------------------------------------------- | ------- |
-| `routing.customHeaders` | List of custom headers used for sandbox routing | `[]`    |
+| Name                    | Description                                                                           | Default  |
+| ----------------------- | ------------------------------------------------------------------------------------- | -------- |
+| `routing.iptablesMode`  | `iptables` variant to use when configuring rules (possible values: `legacy` or `nft`) | `legacy` |
+| `routing.customHeaders` | List of custom headers used for sandbox routing                                       | `[]`     |
+
 
 
 ### Traffic capture parameters

--- a/signadot/operator/templates/_helpers.tpl
+++ b/signadot/operator/templates/_helpers.tpl
@@ -12,6 +12,7 @@ routing:
     enableHostRouting: {{ if and (hasKey .Values "istio") (hasKey .Values.istio "enableDeprecatedHostRouting") -}}{{ toString .Values.istio.enableDeprecatedHostRouting }}{{- else -}}false{{- end }}
   linkerd:
     enabled: {{ if and (hasKey .Values "linkerd") (hasKey .Values.linkerd "enabled") -}}{{ toString .Values.linkerd.enabled }}{{- else -}}false{{- end }}
+  iptablesMode: {{ if and (hasKey .Values "routing") (hasKey .Values.routing "iptablesMode") -}}{{ .Values.routing.iptablesMode }}{{- else -}}legacy{{- end }}
   customHeaders: {{ with .Values }}{{ with .routing }}{{ with .customHeaders }}{{ printf "\n" }}{{ toYaml . | indent 4}}{{- else -}}[]{{- end }}{{- else -}}[]{{- end }}{{- else -}}[]{{- end }}
 sandboxTrafficManager:
   enabled: {{ if and (hasKey .Values "sandboxTrafficManager") (hasKey .Values.sandboxTrafficManager "enabled") -}}{{ toString .Values.sandboxTrafficManager.enabled }}{{- else -}}true{{- end }}

--- a/signadot/operator/templates/agent-deployment.yaml
+++ b/signadot/operator/templates/agent-deployment.yaml
@@ -22,6 +22,8 @@ spec:
   selector:
     matchLabels:
       app: signadot-agent
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/signadot/operator/templates/tunnel-proxy-deployment.yaml
+++ b/signadot/operator/templates/tunnel-proxy-deployment.yaml
@@ -117,6 +117,8 @@ spec:
       {{- if and (not $istioEnabled) (not $linkerdEnabled) $auditorEnabled }}
       initContainers:
       - env:
+        - name: SIGNADOT_IPTABLES_MODE
+          value: {{ with .Values }}{{ with .routing }}{{ with .iptablesMode }}{{ . }}{{- else -}}"legacy"{{- end }}{{- else -}}"legacy"{{- end }}{{- else -}}"legacy"{{- end }}
         - name: LUA_ROCKS
           value: {{ with .Values }}{{ with .tunnel }}{{ with .auditor }}{{ with .luaRocks }}{{ . }}{{- else -}}""{{- end }}{{- else -}}""{{- end }}{{- else -}}""{{- end }}{{- else -}}""{{- end }}
         - name: INBOUND_AUDITOR_PORT

--- a/signadot/operator/values.yaml
+++ b/signadot/operator/values.yaml
@@ -227,6 +227,7 @@ tunnel:
 # -----------------------------------------------------------------------------
 
 # routing:
+#   iptablesMode: nft
 #   # Define a list of custom routing headers
 #   customHeaders:
 #     - header1


### PR DESCRIPTION
Stacked on https://github.com/signadot/charts/pull/71.

## Change description

Addition of `routing.iptablesMode`, this is the result of running `make helm-chart` in https://github.com/signadot/signadot/pull/5269.