### PR TITLE
Ability to customize the secret name (still default to 'cluster-agent')

### DIFF
--- a/signadot/operator/templates/agent-deployment.yaml
+++ b/signadot/operator/templates/agent-deployment.yaml
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: token
-              name: cluster-agent
+              name: {{ .Values.agent.secretName | default "cluster-agent" }}
         image: {{ with .Values }}{{ with .agent }}{{ with .image }}{{ . | quote}}{{- else -}}signadot/agent:v1.0.0{{- end }}{{- else -}}signadot/agent:v1.0.0{{- end }}{{- else -}}signadot/agent:v1.0.0{{- end }}
         imagePullPolicy: {{ with .Values }}{{ with .agent }}{{ with .imagePullPolicy }}{{ . | quote}}{{- else -}}IfNotPresent{{- end }}{{- else -}}IfNotPresent{{- end }}{{- else -}}IfNotPresent{{- end }}
         livenessProbe:


### PR DESCRIPTION
Agent is looking for a secret with the default name of "cluster-agent"

In some cases the secret is generated with a different name. This change adds the ability to specify a different name OR default to 'cluster-agent' if nothing is specified.

