### PR TITLE
Release from "release" branch / manually, not from main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,15 @@
 name: Release Charts
 
+# This workflow creates a new chart release when changes are merged to the release branch.
+# The release branch should only receive changes through pull requests from main.
+# Each merge commit to release represents a deliberate release decision.
+
 on:
   push:
     branches:
-      - main
+      - release
+  workflow_dispatch:
+    # Allow manual trigger for releases
 
 jobs:
   release:

--- a/signadot/operator/Chart.yaml
+++ b/signadot/operator/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.0"
+version: "0.0.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "0.0.0"


### PR DESCRIPTION
## Change description

Currently we cut a release when we merge to main which is restrictive when accumulating changes for the next operator release. This change allows us to use a dedicated release branch named "release" which if pushed to will cut a new release and sets main to use "0.0.0" as a safeguard since we expect never to release directly from it. 


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

Fixes https://github.com/signadot/signadot/issues/6081

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
