### PR TITLE
feat: make operator namespace configurable via values.yaml

### DIFF
--- a/signadot/operator/README.md
+++ b/signadot/operator/README.md
@@ -22,6 +22,20 @@ kubectl create ns signadot
 helm repo add signadot https://charts.signadot.com
 helm install signadot-operator signadot/operator --set controlPlane.clusterToken=$CLUSTER_TOKEN
 ```
+
+To install into a custom namespace (e.g. when your organization enforces a
+namespace naming policy):
+
+```sh
+# Create the custom namespace
+kubectl create ns <CUSTOM_NAMESPACE>
+
+# Install with custom namespace
+helm install signadot-operator signadot/operator \
+  --set controlPlane.clusterToken=$CLUSTER_TOKEN \
+  --set namespace=<CUSTOM_NAMESPACE>
+```
+
 The command deploys Signadot Operator on the Kubernetes cluster with default
 configuration. The [Parameters](#parameters) section lists the parameters that
 can be configured during installation.
@@ -33,15 +47,17 @@ If you installed the chart without a cluster token or would like to rotate the c
 token, you can create the associated secret with
 
 ```sh
-kubectl -n signadot create secret generic cluster-token --from-literal=token=$CLUSTER_TOKEN
+kubectl -n <NAMESPACE> create secret generic cluster-token --from-literal=token=$CLUSTER_TOKEN
 ```
+
+where `<NAMESPACE>` is the namespace where the operator is deployed (default: `signadot`).
 
 To rotate the secret, update the existing secret with the new value. Running
 services will automatically detect the change and begin using the updated
 secret. E.g.:
 
 ```sh
-kubectl -n signadot patch secret cluster-token \
+kubectl -n <NAMESPACE> patch secret cluster-token \
   --type=merge -p '{"stringData":{"token":"'"$CLUSTER_TOKEN"'"}}'
 ```
 
@@ -67,7 +83,7 @@ To uninstall/delete the `signadot-operator` deployment:
 # Uninstall
 helm uninstall signadot-operator
 
-# Remove signadot namespace
+# Remove the namespace (replace signadot with your custom namespace if applicable)
 kubectl delete ns signadot
 ```
 
@@ -75,15 +91,16 @@ kubectl delete ns signadot
 
 ### Common parameters
 
-| Name                 | Description                                               | Default  |
-| -------------------- | --------------------------------------------------------- | -------- |
-| `commonLabels`       | Labels to add to all deployed objects                     | `{}`     |
-| `commonAnnotations`  | Annotations to add to all deployed objects                | `{}`     |
-| `podLabels`          | Labels to add to all deployed `Pod` objects               | `{}`     |
-| `podAnnotations`     | Annotations to add to all deployed `Pod` objects          | `{}`     |
-| `serviceLabels`      | Labels to add to all deployed `Service` objects           | `{}`     |
-| `serviceAnnotations` | Annotations to add to all deployed `Service` objects      | `{}`     |
-| `imagePullSecrets`   | List of image pull secret names for all deployments       | `[]`     |
+| Name                 | Description                                               | Default     |
+| -------------------- | --------------------------------------------------------- | ----------- |
+| `namespace`          | Namespace where the operator is deployed                  | `signadot`  |
+| `commonLabels`       | Labels to add to all deployed objects                     | `{}`        |
+| `commonAnnotations`  | Annotations to add to all deployed objects                | `{}`        |
+| `podLabels`          | Labels to add to all deployed `Pod` objects               | `{}`        |
+| `podAnnotations`     | Annotations to add to all deployed `Pod` objects          | `{}`        |
+| `serviceLabels`      | Labels to add to all deployed `Service` objects           | `{}`        |
+| `serviceAnnotations` | Annotations to add to all deployed `Service` objects      | `{}`        |
+| `imagePullSecrets`   | List of image pull secret names for all deployments       | `[]`        |
 
 
 ### Image and replicas customization parameters

--- a/signadot/operator/templates/_helpers.tpl
+++ b/signadot/operator/templates/_helpers.tpl
@@ -1,4 +1,13 @@
 {{/*
+operator.namespace - get the operator deployment namespace
+Defaults to "signadot" for backward compatibility.
+Override via .Values.namespace to install into a custom namespace.
+*/}}
+{{- define "operator.namespace" -}}
+{{- .Values.namespace | default "signadot" -}}
+{{- end -}}
+
+{{/*
 valuesDefault - dig into .Values with a default fallback
 Usage: {{ include "valuesDefault" (list .Values "defaultValue" "path" "to" "value") }}
 */}}
@@ -29,13 +38,14 @@ false
 {{- end }}
 
 {{/*
-getAllowedNamespaces - get allowed namespaces, always including signadot
+getAllowedNamespaces - get allowed namespaces, always including the operator namespace
 */}}
 {{- define "getAllowedNamespaces" -}}
+{{- $operatorNs := include "operator.namespace" . -}}
 {{- if .Values.allowedNamespaces }}
   {{- $userNamespaces := .Values.allowedNamespaces -}}
-  {{- if not (has "signadot" $userNamespaces) }}
-    {{- $userNamespaces = append $userNamespaces "signadot" -}}
+  {{- if not (has $operatorNs $userNamespaces) }}
+    {{- $userNamespaces = append $userNamespaces $operatorNs -}}
   {{- end }}
 {{- $userNamespaces | toJson -}}
 {{- else -}}
@@ -75,7 +85,7 @@ Checks .Values.controlPlane.tokenSecret, then looks up existing "cluster-agent" 
 then falls back to "cluster-token"
 */}}
 {{- define "tokenSecretName" -}}
-{{- $oldSecret := (lookup "v1" "Secret" "signadot" "cluster-agent") -}}
+{{- $oldSecret := (lookup "v1" "Secret" (include "operator.namespace" .) "cluster-agent") -}}
 {{- if and .Values.controlPlane .Values.controlPlane.tokenSecret -}}
 {{- .Values.controlPlane.tokenSecret -}}
 {{- else if $oldSecret.metadata -}}

--- a/signadot/operator/templates/agent-deployment.yaml
+++ b/signadot/operator/templates/agent-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   replicas: 1
   selector:

--- a/signadot/operator/templates/agent-metrics-service.yaml
+++ b/signadot/operator/templates/agent-metrics-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
     app: signadot-agent
   name: agent-metrics
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   type: ClusterIP
   ports:

--- a/signadot/operator/templates/agent-serviceaccount.yaml
+++ b/signadot/operator/templates/agent-serviceaccount.yaml
@@ -11,4 +11,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/allowed_namespaces.yaml
+++ b/signadot/operator/templates/allowed_namespaces.yaml
@@ -15,7 +15,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" $ }}
 {{ end }}
 # Bind the ClusterRole containing agent permissions to the agent's
 # ServiceAccount only in the specified namespaces.
@@ -33,5 +33,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" $ }}
 {{ end }}

--- a/signadot/operator/templates/cluster-config-configmap.yaml
+++ b/signadot/operator/templates/cluster-config-configmap.yaml
@@ -14,4 +14,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: cluster-config
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/cluster-token-secret.yaml
+++ b/signadot/operator/templates/cluster-token-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ with .Values }}{{ with .controlPlane }}{{ with .tokenSecret }}{{ . }}{{- else -}}cluster-token{{- end }}{{- else -}}cluster-token{{- end }}{{- else -}}cluster-token{{- end }}
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 data:
   token: {{ .Values.controlPlane.clusterToken | b64enc | quote }}
 {{- end }}

--- a/signadot/operator/templates/io-context-server-deployment.yaml
+++ b/signadot/operator/templates/io-context-server-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: io-context-server
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   replicas:
     {{- with .Values.ioContextServer }}{{- with .replicas }} {{ . }}

--- a/signadot/operator/templates/io-context-server-metrics-service.yaml
+++ b/signadot/operator/templates/io-context-server-metrics-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
     app: io-context-server
   name: io-context-server-metrics
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   type: ClusterIP
   ports:

--- a/signadot/operator/templates/io-context-server-service.yaml
+++ b/signadot/operator/templates/io-context-server-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: io-context-server
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   selector:
     app: io-context-server

--- a/signadot/operator/templates/io-context-server-serviceaccount.yaml
+++ b/signadot/operator/templates/io-context-server-serviceaccount.yaml
@@ -11,4 +11,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: io-context-server
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/routeserver-deployment.yaml
+++ b/signadot/operator/templates/routeserver-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: routeserver
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   replicas: 1
   selector:

--- a/signadot/operator/templates/routeserver-metrics-service.yaml
+++ b/signadot/operator/templates/routeserver-metrics-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
     app: routeserver
   name: routeserver-metrics
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   type: ClusterIP
   selector:

--- a/signadot/operator/templates/routeserver-service.yaml
+++ b/signadot/operator/templates/routeserver-service.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
     app: routeserver
   name: routeserver
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   type: ClusterIP
   selector:

--- a/signadot/operator/templates/routeserver-serviceaccount.yaml
+++ b/signadot/operator/templates/routeserver-serviceaccount.yaml
@@ -11,4 +11,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: routeserver
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-agent-clusterrolebinding.yaml
+++ b/signadot/operator/templates/signadot-agent-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-agent-namespaced-clusterrolebinding.yaml
+++ b/signadot/operator/templates/signadot-agent-namespaced-clusterrolebinding.yaml
@@ -18,6 +18,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 {{ end }}
 # This file is generated. Do not edit.

--- a/signadot/operator/templates/signadot-agent-role.yaml
+++ b/signadot/operator/templates/signadot-agent-role.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/signadot/operator/templates/signadot-agent-rolebinding.yaml
+++ b/signadot/operator/templates/signadot-agent-rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -19,4 +19,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-controller-manager-deployment.yaml
+++ b/signadot/operator/templates/signadot-controller-manager-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- end }}
     control-plane: controller-manager
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   replicas:
     {{- with .Values.controllerManager }}{{- with .replicas }} {{ . }}

--- a/signadot/operator/templates/signadot-controller-manager-metrics-service.yaml
+++ b/signadot/operator/templates/signadot-controller-manager-metrics-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
     control-plane: controller-manager
   name: signadot-controller-manager-metrics
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   selector:
     control-plane: controller-manager

--- a/signadot/operator/templates/signadot-controller-manager-serviceaccount.yaml
+++ b/signadot/operator/templates/signadot-controller-manager-serviceaccount.yaml
@@ -11,4 +11,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-io-context-server-role.yaml
+++ b/signadot/operator/templates/signadot-io-context-server-role.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-io-context-server
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/signadot/operator/templates/signadot-io-context-server-rolebinding.yaml
+++ b/signadot/operator/templates/signadot-io-context-server-rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-io-context-server
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -19,4 +19,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: io-context-server
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-leader-election-role-role.yaml
+++ b/signadot/operator/templates/signadot-leader-election-role-role.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-leader-election-role
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/signadot/operator/templates/signadot-leader-election-rolebinding-rolebinding.yaml
+++ b/signadot/operator/templates/signadot-leader-election-rolebinding-rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-leader-election-rolebinding
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -19,4 +19,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-manager-config-configmap.yaml
+++ b/signadot/operator/templates/signadot-manager-config-configmap.yaml
@@ -24,4 +24,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-manager-config
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-manager-namespaced-clusterrolebinding.yaml
+++ b/signadot/operator/templates/signadot-manager-namespaced-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-manager-role-role.yaml
+++ b/signadot/operator/templates/signadot-manager-role-role.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-manager-role
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/signadot/operator/templates/signadot-manager-rolebinding-clusterrolebinding.yaml
+++ b/signadot/operator/templates/signadot-manager-rolebinding-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-manager-rolebinding-rolebinding.yaml
+++ b/signadot/operator/templates/signadot-manager-rolebinding-rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-manager-rolebinding
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -19,4 +19,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/signadot/operator/templates/signadot-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -17,7 +17,7 @@ webhooks:
   clientConfig:
     service:
       name: signadot-webhook-service
-      namespace: signadot
+      namespace: {{ include "operator.namespace" . }}
       path: /mutate-v1-pod
   failurePolicy: Ignore
   name: sidecar-injector.signadot.com

--- a/signadot/operator/templates/signadot-proxy-rolebinding-clusterrolebinding.yaml
+++ b/signadot/operator/templates/signadot-proxy-rolebinding-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: signadot-controller-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-routeserver-clusterrolebinding.yaml
+++ b/signadot/operator/templates/signadot-routeserver-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: routeserver
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/signadot-webhook-service-service.yaml
+++ b/signadot/operator/templates/signadot-webhook-service-service.yaml
@@ -17,7 +17,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: signadot-webhook-service
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   ports:
   - port: 443

--- a/signadot/operator/templates/traffic-manager-clusterrole.yaml
+++ b/signadot/operator/templates/traffic-manager-clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: traffic-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/signadot/operator/templates/traffic-manager-clusterrolebinding.yaml
+++ b/signadot/operator/templates/traffic-manager-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: traffic-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/traffic-manager-deployment.yaml
+++ b/signadot/operator/templates/traffic-manager-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: traffic-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   replicas:
     {{- with .Values.trafficManager }}{{- with .replicas }} {{ . }}

--- a/signadot/operator/templates/traffic-manager-service.yaml
+++ b/signadot/operator/templates/traffic-manager-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: traffic-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   selector:
     app: traffic-manager

--- a/signadot/operator/templates/traffic-manager-serviceaccount.yaml
+++ b/signadot/operator/templates/traffic-manager-serviceaccount.yaml
@@ -11,4 +11,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: traffic-manager
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/tunnel-api-clusterrolebinding.yaml
+++ b/signadot/operator/templates/tunnel-api-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tunnel-api
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/tunnel-api-config-role.yaml
+++ b/signadot/operator/templates/tunnel-api-config-role.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-api-config
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/signadot/operator/templates/tunnel-api-config-rolebinding.yaml
+++ b/signadot/operator/templates/tunnel-api-config-rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-api-config
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -19,4 +19,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tunnel-api
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/tunnel-api-deployment.yaml
+++ b/signadot/operator/templates/tunnel-api-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-api
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   replicas:
     {{- with .Values.tunnel }}{{- with .api }}{{- with .replicas }} {{ . }}

--- a/signadot/operator/templates/tunnel-api-service.yaml
+++ b/signadot/operator/templates/tunnel-api-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-api
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   selector:
     app: tunnel-api

--- a/signadot/operator/templates/tunnel-api-serviceaccount.yaml
+++ b/signadot/operator/templates/tunnel-api-serviceaccount.yaml
@@ -11,4 +11,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-api
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/tunnel-cidrs-configmap.yaml
+++ b/signadot/operator/templates/tunnel-cidrs-configmap.yaml
@@ -17,4 +17,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-cidrs
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/tunnel-proxy-clusterrolebinding.yaml
+++ b/signadot/operator/templates/tunnel-proxy-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tunnel-proxy
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/tunnel-proxy-deployment.yaml
+++ b/signadot/operator/templates/tunnel-proxy-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-proxy
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   replicas:
     {{- with .Values.tunnel }}{{- with .proxy }}{{- with .replicas }} {{ . }}

--- a/signadot/operator/templates/tunnel-proxy-metrics-service.yaml
+++ b/signadot/operator/templates/tunnel-proxy-metrics-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
     app: tunnel-proxy
   name: tunnel-proxy-metrics
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   type: ClusterIP
   ports:

--- a/signadot/operator/templates/tunnel-proxy-role.yaml
+++ b/signadot/operator/templates/tunnel-proxy-role.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-proxy
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/signadot/operator/templates/tunnel-proxy-rolebinding.yaml
+++ b/signadot/operator/templates/tunnel-proxy-rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-proxy
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -19,4 +19,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tunnel-proxy
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/templates/tunnel-proxy-service.yaml
+++ b/signadot/operator/templates/tunnel-proxy-service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-proxy
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}
 spec:
   selector:
     app: tunnel-proxy

--- a/signadot/operator/templates/tunnel-proxy-serviceaccount.yaml
+++ b/signadot/operator/templates/tunnel-proxy-serviceaccount.yaml
@@ -11,4 +11,4 @@ metadata:
     {{ $key | quote }}: {{ $val | quote }}
     {{- end }}
   name: tunnel-proxy
-  namespace: signadot
+  namespace: {{ include "operator.namespace" . }}

--- a/signadot/operator/values.yaml
+++ b/signadot/operator/values.yaml
@@ -2,6 +2,14 @@
 # All values are optional - defaults are embedded in templates
 
 
+# Namespace where the operator is deployed.
+# Defaults to "signadot". Override this if your organization's namespace
+# naming policy requires a different namespace name.
+# Example:
+#   namespace: signadot-custom-ns
+namespace: signadot
+
+
 # Common settings
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Related Issue

- Fixes signadot/community#142 

## What and Why

The operator chart hardcodes `namespace: signadot` in 58 places across all template files,
making it impossible to install into any other namespace.

This PR adds a `namespace` parameter to `values.yaml` (default: `"signadot"`) and replaces
all hardcoded references with `{{ include "operator.namespace" . }}`.

## Backward Compatibility

**Fully backward compatible** — the default is `"signadot"`, so existing installations
require no changes.

```sh
# Existing — unchanged behavior
helm install signadot-operator signadot/operator --set controlPlane.clusterToken=$CLUSTER_TOKEN

# New: custom namespace
helm install signadot-operator signadot/operator \
  --set controlPlane.clusterToken=$CLUSTER_TOKEN \
  --set namespace=<CUSTOM_NAMESPACE>
```

### Note on Generated Files

Some templates contain # This file is generated. Do not edit. comments.
If there is an upstream generator, please advise if changes should be applied there instead.

### Alternative Approaches

Merging this PR as-is is not required — any solution that makes the deployment namespace
configurable would work for us. That said, this is a blocking issue for our platform
and we would greatly appreciate a fix as soon as possible.
