### PR TITLE
ci: pin GitHub Actions to SHAs (ENG-921)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -25,12 +25,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.4.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: signadot
           charts_repo_url: https://charts.signadot.com


### PR DESCRIPTION
## Summary

Pin all GitHub Actions in `release.yml` to full commit SHAs with major tag comments. Add a `github-actions` Dependabot config.

The previous refs were significantly out of date (`actions/checkout@v2`, `azure/setup-helm@v1` are EOL Node 16 runtimes; `helm/chart-releaser-action@v1.2.1` is two years old), so the pin doubles as a deferred upgrade to current stable majors.

### Pinned actions

- `actions/checkout` v2 -> v4 `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `azure/setup-helm` v1 -> v4 `1a275c3b69536ee54be43f2070a358922e12c8d4`
- `helm/chart-releaser-action` v1.2.1 -> v1.7.0 `cae68fefc6b5f367a0275617c9f83181ba54714f`

## Test plan

- [ ] On merge to `main`, the release workflow successfully publishes the next chart version to https://charts.signadot.com
- [ ] Dependabot picks up the new `github-actions` ecosystem

Refs https://linear.app/signadot/issue/ENG-921
